### PR TITLE
Fix bug when eventData is a PSCustomObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # UMN-Common
 
+## 1.0.11 - 12/10/2019
+Fixed bug in Send-SplunkHEC when eventData was a PSCustomObject.
+Changed code to make copy of metadata hashtable rather than modifying in place
+Renamed Host parameter in Send-SplunkHEC to EventHost (and added alias for backwards compatiblity)
+
 ## 1.0.10 - 12/9/2019
 Modifed send-SplunkHEC to retry if the initial invoke-restMethod fails
 

--- a/UMN-Common.psd1
+++ b/UMN-Common.psd1
@@ -28,7 +28,7 @@
 RootModule = 'UMN-Common.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.10'
+ModuleVersion = '1.0.11'
 
 # ID used to uniquely identify this module
 GUID = '4a7ba823-deb0-4b4d-9f81-396b20c8784b'
@@ -121,7 +121,11 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Updated splunk function to retry if invoke to HEC URI fails on invoke-restmethod'
+        ReleaseNotes = @"
+Fixed bug in Send-SplunkHEC when eventData was a PSCustomObject.
+Changed code to make copy of metadata hashtable rather than modifying in place
+Renamed Host parameter in Send-SplunkHEC to EventHost (and added alias for backwards compatiblity)
+"@
 
     } # End of PSData hashtable
 


### PR DESCRIPTION
1.  Removed "Host" parameter and replaced it with EventHost because `$host` is a reserved variable (added Host as an alias for EventHost parameter to maintain backwards compatiblity)
2. Uses a clone of metadata instead of the metadata object directly, because the code modifies that object and the passed in data shouldn't be modified
3. Fixes the issue where EventData is a PSCustomObject.  PSCustomObject doesn't have an Add method so there would be a failure when EventData was a PSCustomObject
4. Since the Retry code modifies the event data, this makes a copy of the event data rather than modifying in place, for the same reason as $metadata is now a clone
5. Renamed the paramaeter to "SplunkHECRetry" to reduce likely hood of a collision with data passed in

This creates a new object `$InternalEventData` by converting event data to Json and back from Json, which will create a PSCustomObject that is different from what is passed in.  And this will work if Event Data is a Hashtable or a PSCustomObject.  Once we know it's a PSCustomObject we know we can use AddMember to add the SplunkHECRetry property.

I tested passing in both a Hashtable and a PSCustomObject, and also tested the retry functionality by disconnecting my network and running the command, then plugging it back in, and the SplunkHECRetry property was 2 in the event data that did make it to Splunk